### PR TITLE
fix : .eo 파일이 업로드 후 추가되지 않는 버그 수정

### DIFF
--- a/src/renderer/helper/entry/entryModalHelper.ts
+++ b/src/renderer/helper/entry/entryModalHelper.ts
@@ -148,6 +148,7 @@ class EntryModalHelper {
                                 if (firstObject.objectType === 'textBox') {
                                     // selected = firstObject;
                                     selected = {
+                                        sprite: objectModel,
                                         name: firstObject.name,
                                         text: firstObject.text,
                                         objectType: firstObject.objectType,
@@ -158,7 +159,6 @@ class EntryModalHelper {
                                     };
                                 }
 
-                                selected.sprite = objectModel;
                                 return selected;
                             })
                         ),


### PR DESCRIPTION
### 원인
- sprite객체 내부에 sprite를 할당하면서 순환참조가 발생

### 해결
- 오브젝트가 textbox일 경우만 sprite를 넣어주도록 수정